### PR TITLE
test(pathfinder)+docs(sdd): 形状锁测试 + D-14 追认 delivered 终态

### DIFF
--- a/docs/plan/2026-07-19-pathfinder-mode.md
+++ b/docs/plan/2026-07-19-pathfinder-mode.md
@@ -1,6 +1,7 @@
 # SDD — Pathfinder Mode（渐进散雾式规划）
 
-> 状态：契约草案，待 owner 确认接缝后开工。
+> 状态：已实装（`a44accd` feat + `5e23e0c` review 修复批，2026-07-19）。本文档保留为设计记录；
+> 数据模型 `delivered` 终态由 D-14 追认（2026-07-20）。
 > 说明：本该用 pathfinder 自己画地图（dogfood），但 pathfinder 尚不存在，且经过多轮对话
 > 迷雾已散尽（决策全部裁决 = 见 D-numbers），故直接落为 SDD spec 而非决策地图。
 
@@ -34,6 +35,7 @@
 | D-10 | 票自我展开：research 票用 **map 节点**原语运行时发现子票 | 引擎原生，Matt 原版无此 |
 | D-11 | 出口：区域散尽→票编译 slice→/execute；填不出契约=有票没解=回地图（升级阀 `?`） | 只组装不发明，防地图偏移 |
 | D-12 | `/sdd`(spec,小活) 与 pathfinder(大活) 并存不合并；plan mode 零件(gate/ledger/overlay/best-of-n)搬进 pathfinder 复用 | 各尺度合身入口，非单一入口 |
+| D-14 | `TicketStatus` 增 **`delivered`** 终态（slice 已交付；实装先行，owner 2026-07-20 追认） | `/deliver` 交付闭环需要终态，承 D-11 区域 delivered 语义；原四值模型漏列 |
 
 ## 架构
 
@@ -55,7 +57,7 @@
 
 ```ts
 type TicketType = 'research' | 'grill' | 'prototype' | 'task';
-type TicketStatus = 'open' | 'blocked' | 'ruled' | 'escalated'; // escalated = ? 上报 owner
+type TicketStatus = 'open' | 'blocked' | 'ruled' | 'delivered' | 'escalated'; // delivered = slice 已交付终态(D-14); escalated = ? 上报 owner
 interface Ticket {
   id: string;              // 稳定 id
   type: TicketType;

--- a/src/harness/pathfinder/types.test.ts
+++ b/src/harness/pathfinder/types.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import type { ExecutorKind, PathMap, Ticket, TicketStatus, TicketType } from './types';
+
+/**
+ * 数据模型形状契约 (SDD §数据模型 verbatim): 字段不增不减, 枚举值不增。
+ * 类型在运行时擦除 → 用全类型构造 (编译期 satisfies) + Object.keys (运行期) 双向锁形状。
+ * TicketStatus 第五值 'delivered' 由 D-14 追认 (2026-07-20 owner 裁决, 原 SDD 四值模型漏列)。
+ */
+
+const TICKET_TYPES = ['research', 'grill', 'prototype', 'task'] as const satisfies readonly TicketType[];
+const TICKET_STATUSES = ['open', 'blocked', 'ruled', 'delivered', 'escalated'] as const satisfies readonly TicketStatus[];
+const EXECUTOR_KINDS = ['command', 'inproc', 'agent', 'map', 'primitive'] as const satisfies readonly ExecutorKind[];
+
+describe('types (SDD §数据模型)', () => {
+  test('TicketType = SDD 四值 (D-9)', () => {
+    expect([...TICKET_TYPES].sort()).toEqual(['grill', 'prototype', 'research', 'task']);
+  });
+
+  test('TicketStatus = SDD 四值 + delivered 终态 (D-14)', () => {
+    expect([...TICKET_STATUSES].sort()).toEqual(['blocked', 'delivered', 'escalated', 'open', 'ruled']);
+  });
+
+  test('ExecutorKind = SDD 五值 (不发明新 kind)', () => {
+    expect([...EXECUTOR_KINDS].sort()).toEqual(['agent', 'command', 'inproc', 'map', 'primitive']);
+  });
+
+  test('Ticket 必填字段 = id/type/title/blockedBy/status, 不增不减', () => {
+    const minimal: Ticket = { id: 't1', type: 'grill', title: '?', blockedBy: [], status: 'open' };
+    expect(Object.keys(minimal).sort()).toEqual(['blockedBy', 'id', 'status', 'title', 'type']);
+  });
+
+  test('Ticket 可选字段 = ruling/executorKind/children/dNumber (SDD 列全)', () => {
+    const full: Ticket = {
+      id: 't2',
+      type: 'task',
+      title: '施工',
+      blockedBy: ['t1'],
+      status: 'ruled',
+      ruling: '按 D-7 拆',
+      executorKind: 'command',
+      children: ['t3'],
+      dNumber: 'D-7',
+    };
+    expect(Object.keys(full).sort()).toEqual([
+      'blockedBy', 'children', 'dNumber', 'executorKind', 'id', 'ruling', 'status', 'title', 'type',
+    ]);
+  });
+
+  test('PathMap 字段 = destination/slug/tickets/decisionsLog, 不增不减', () => {
+    const map: PathMap = {
+      destination: 'pathfinder 模式',
+      slug: 'pathfinder-mode',
+      tickets: [],
+      decisionsLog: [{ ticketId: 't1', gist: '裁: 是' }],
+    };
+    expect(Object.keys(map).sort()).toEqual(['decisionsLog', 'destination', 'slug', 'tickets']);
+    expect(Object.keys(map.decisionsLog[0]!).sort()).toEqual(['gist', 'ticketId']);
+  });
+
+  test('四票型 × 全 executorKind 均可构造 (类型驱动分派, D-9)', () => {
+    const tickets: Ticket[] = TICKET_TYPES.flatMap((type, i) =>
+      EXECUTOR_KINDS.map((executorKind, j) => ({
+        id: `t${i}-${j}`, type, title: type, blockedBy: [] as string[], status: 'open' as const, executorKind,
+      })),
+    );
+    expect(tickets).toHaveLength(20);
+  });
+});


### PR DESCRIPTION
## 内容

Pathfinder P0 外部审查批（Aalto 监督 · Kimi K3 dogfood 首跑产物）：

1. **`src/harness/pathfinder/types.test.ts`（新增）** — SDD §数据模型形状契约测试：
   编译期 `satisfies` + 运行期 `Object.keys` 双向锁死 `Ticket`/`PathMap` 字段与
   `TicketType`/`TicketStatus`/`ExecutorKind` 枚举值，防后续实装静默漂移。
   出处：`dag-build` 派 `kimi-coding:k3` 重建 P0 的首次 dogfood 跑（judge 因目标已实装
   hard_fail 截停，本测试为唯一幸存产物，人工复核后收编）。
2. **SDD `docs/plan/2026-07-19-pathfinder-mode.md`** —
   - 状态头从「契约草案待开工」改为「已实装」（`a44accd` + `5e23e0c`），文档转设计记录；
   - **D-14 追认 `TicketStatus` 第五值 `delivered`**（slice 已交付终态）：实装先行、
     原四值模型漏列，owner 2026-07-20 裁决保留（承 D-11 区域 delivered 语义）；
   - 数据模型代码块同步补 `delivered`。

## 验证

- `bun test src/harness/pathfinder/` 全绿（73+ 测试含本新增文件）。
- 改动零运行时代码：仅测试 + 文档。

## 背景

该 dogfood 跑同时暴露一个引擎缺陷（`--oracle-cmd` 含 `&&` 被图内 command-leaf
防注入闸拒绝，gate 节点必败），另开 issue 跟踪。