### PR TITLE
fix(executor-dag): oracle 复跑 command 节点执行前确定性过滤 (closes #2)

### DIFF
--- a/scripts/dag-build.ts
+++ b/scripts/dag-build.ts
@@ -126,8 +126,14 @@ const continuityManager = new CheckpointManager(repoRoot);
 const continuityRunId = flags.resume || `build-${dispatchId}`;
 process.stderr.write(`[dag-build] continuity runId=${continuityRunId}${flags.resume ? ' (resume: 跳已绿节点)' : ''}\n`);
 
+// oracle 命令可覆盖: 默认 tsc; 非 ts 项目 (如 Astro) 传 --oracle-cmd "npx astro check"。
+// 单一定义: 外层 oracle 闸与图内 oracle 复跑节点过滤器 (issue #2) 必须字节一致。
+const oracleCmd = flags['oracle-cmd'] || 'bun run tsc --noEmit';
+
 // DAG 配置 (初次 build + 自愈 fix-DAG 复用同一套)
 const dagConfig = {
+  // issue #2: conductor 规划出与 oracle 等价的 command 节点会被 command-leaf 元字符闸误拒 → 执行前确定性过滤。
+  oracleCmd,
   continuity: { manager: continuityManager, runId: continuityRunId, resume: !!flags.resume, repoRoot },
   conductorModel,
   leafModel,
@@ -183,8 +189,6 @@ export interface OracleResult {
   testFail: string[];
 }
 async function runOracle(): Promise<OracleResult> {
-  // oracle 命令可覆盖: 默认 tsc; 非 ts 项目 (如 Astro) 传 --oracle-cmd "npx astro check"。
-  const oracleCmd = flags['oracle-cmd'] || 'bun run tsc --noEmit';
   const tsc = await $`sh -c ${oracleCmd}`.nothrow().quiet();
   const rawOut = tsc.stdout.toString() + tsc.stderr.toString();
   let tscErrs = rawOut.split('\n').filter((l) => /error TS/.test(l) && !l.includes('node_modules'));

--- a/src/harness/executor-dag-planner.ts
+++ b/src/harness/executor-dag-planner.ts
@@ -69,3 +69,6 @@ export function buildLeafPrompt(
 export function addUsage(a: ModelUsage, b: ModelUsage): ModelUsage {
   return { in: a.in + b.in, out: a.out + b.out, cacheHit: (a.cacheHit ?? 0) + (b.cacheHit ?? 0) };
 }
+
+// ── plan 过滤器 (plan 落地后、执行前的确定性挂点) ────────────────────────────
+export { filterOracleCommandNodes } from './oracle-plan-filter';

--- a/src/harness/executor-dag-types.ts
+++ b/src/harness/executor-dag-types.ts
@@ -92,6 +92,13 @@ export interface ExecutorDagConfig {
    */
   commandRunner?: CommandLeafRunner;
   /**
+   * oracle 命令 (如 "bun run typecheck && bun test"): plan 中 command 与之等价的节点
+   * 在执行前被确定性过滤 (空白规范化后精确匹配, 最小无害边重连)。
+   * 选型理由: oracle 已跑过该命令, conductor 重规划出等价节点 = 浪费 token + 时间。
+   * 省略 = 不过滤 (向后兼容)。
+   */
+  oracleCmd?: string;
+  /**
    * 跨模型校验器 (model-agnostic skeptic, 见 verifier.ts)。省略 = 不校验 (back-compat 老行为)。
    * 给则 DAG 跑完用它审结果 → fail 且配了可用升级模型时触发 conductor 静默升级重规划。
    */

--- a/src/harness/executor-dag.ts
+++ b/src/harness/executor-dag.ts
@@ -32,7 +32,7 @@ import { logger } from './logger';
 // ── T2#5 按簇拆出的兄弟文件 (引擎消费) ──
 import type { GenerateFn, ExecutorDagConfig, LeafResult, ExecutorDagResult } from './executor-dag-types';
 import { makeDefaultGenerate, LEAF_SYSTEM_PREFIX, PONYTAIL_LEAF_DISPOSITION } from './executor-dag-defaults';
-import { topoLevels, buildLeafPrompt, addUsage } from './executor-dag-planner';
+import { topoLevels, buildLeafPrompt, addUsage, filterOracleCommandNodes } from './executor-dag-planner';
 import { loadAgentTemplates, templateRoster, type AgentTemplate } from './agent-templates';
 import { expandMapNode, mapSpecHash } from './plan/map-expand';
 // SDD 0013 S1 约束选择: primitive 节点 → compile(复用 primitives.ts)→ run。
@@ -91,8 +91,10 @@ async function planAndExecute(
   }
   if (!plan) throw new Error(`executor-dag: conductor (${conductorModel}) 未产出有效 plan: ${lastErr}`);
 
+  // 确定性过滤: plan 中 command 与 oracleCmd 等价的节点移除 (oracle 已跑过, 重跑 = 浪费)。
+  const filteredPlan = config.oracleCmd ? filterOracleCommandNodes(plan, config.oracleCmd) : plan;
   // conductor 之后, 下游执行机器与 plan 来源无关 → 交 executePlan (D-7 预构造入口共用同一机器)。
-  return executePlan(plan, task, config, generate, conductorUsage, templates);
+  return executePlan(filteredPlan, task, config, generate, conductorUsage, templates);
 }
 
 /**
@@ -625,9 +627,13 @@ async function runDagInternal(
 
   let conductorModel = config.conductorModel ?? '';
   // D-7: 预构造 plan → executePlan 直执 (跳过 conductor); 否则 conductor 规划 → 执行。二者下游同一机器。
-  let exec = prebuiltPlan
-    ? await executePlan(prebuiltPlan, task, config, generate, { in: 0, out: 0 }, templates)
-    : await planAndExecute(task, config, conductorModel, generate, maxPlanRetries, templates);
+  let exec: ExecOnce;
+  if (prebuiltPlan) {
+    const filteredPlan = config.oracleCmd ? filterOracleCommandNodes(prebuiltPlan, config.oracleCmd) : prebuiltPlan;
+    exec = await executePlan(filteredPlan, task, config, generate, { in: 0, out: 0 }, templates);
+  } else {
+    exec = await planAndExecute(task, config, conductorModel, generate, maxPlanRetries, templates);
+  }
   let conductorUsage = exec.conductorUsage;
   let leavesIn = exec.leavesIn;
   let leavesOut = exec.leavesOut;

--- a/src/harness/oracle-plan-filter.test.ts
+++ b/src/harness/oracle-plan-filter.test.ts
@@ -1,0 +1,231 @@
+/**
+ * 红测试: oracle-plan-filter —— plan 内 command 节点与 oracle-cmd 等价或被其包含时过滤。
+ *
+ * 契约:
+ *  - oracle-cmd = "bun run typecheck && bun test"
+ *  - plan 中 command 内容与之等价 (含空白差异: 多余空格/换行/Tab) 的节点 → 被移除/中和
+ *  - plan 中 command 是 oracle-cmd 子串 (被 oracle 包含) 的节点 → 被移除/中和
+ *  - plan 中 command 是 oracle-cmd 超集 (包含 oracle) 的节点 → 不移除 (conductor 额外步骤)
+ *  - 被删节点下游 depends_on 被无害重接 (无悬空引用, topoLevels 不报环)
+ *  - 非 oracle 来源、含 && 元字符的 command 节点 → 仍被 command-leaf 元字符闸拒绝 (闸未放宽)
+ */
+import { describe, expect, test } from 'bun:test';
+import type { ConductorPlan } from './conductor-plan';
+import { topoLevels } from './executor-dag';
+import { createCommandLeafRunner } from './command-leaf';
+
+// ── 待实现 (import 即红) ──────────────────────────────────────────────────────
+import { filterOracleCommandNodes } from './oracle-plan-filter';
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const ORACLE_CMD = 'bun run typecheck && bun test';
+
+/** 基础 plan: verify 节点依赖一个与 oracle-cmd 等价的 command 节点。 */
+function basePlan(): ConductorPlan {
+  return {
+    name: 'test-plan',
+    nodes: {
+      setup: { executor: 'leaf', goal: 'setup env' },
+      verify: {
+        executor: 'command',
+        command: ORACLE_CMD,
+        depends_on: ['setup'],
+      },
+      report: {
+        executor: 'leaf',
+        goal: 'write report',
+        depends_on: ['verify'],
+      },
+    },
+  };
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/** 验证 plan 无悬空 depends_on 引用 + 拓扑无环。 */
+function assertGraphSound(plan: ConductorPlan): void {
+  const idSet = new Set(Object.keys(plan.nodes));
+  for (const [id, node] of Object.entries(plan.nodes)) {
+    for (const dep of node.depends_on ?? []) {
+      expect(idSet.has(dep)).toBe(true); // 无悬空引用
+    }
+  }
+  expect(() => topoLevels(plan)).not.toThrow(); // 无环
+}
+
+// ── 1. 过滤器: 移除/中和 oracle 等价节点 ──────────────────────────────────────
+
+describe('filterOracleCommandNodes', () => {
+  test('精确匹配移除 oracle-cmd 节点', () => {
+    const plan = basePlan();
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+    expect(Object.keys(filtered.nodes)).toContain('setup');
+    expect(Object.keys(filtered.nodes)).toContain('report');
+  });
+
+  test('多余空格变体仍被移除', () => {
+    const plan = basePlan();
+    plan.nodes['verify']!.command = 'bun  run typecheck  &&  bun  test';
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+  });
+
+  test('换行变体仍被移除', () => {
+    const plan = basePlan();
+    plan.nodes['verify']!.command = 'bun run typecheck\n&& bun test';
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+  });
+
+  test('Tab 变体仍被移除', () => {
+    const plan = basePlan();
+    plan.nodes['verify']!.command = 'bun run typecheck\t&&\tbun test';
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+  });
+
+  test('前缀/后缀空白变体仍被移除', () => {
+    const plan = basePlan();
+    plan.nodes['verify']!.command = '  bun run typecheck && bun test  \n';
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+  });
+  test('command 是 oracle 子串 (被 oracle 包含) → 移除', () => {
+    const plan = basePlan();
+    // oracle = "bun run typecheck && bun test"; command = "bun run typecheck" (子串)
+    plan.nodes['verify']!.command = 'bun run typecheck';
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+  });
+
+  test('command 是 oracle 的另一子串 (被 oracle 包含) → 移除', () => {
+    const plan = basePlan();
+    // oracle = "bun run typecheck && bun test"; command = "bun test" (子串)
+    plan.nodes['verify']!.command = 'bun test';
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+  });
+
+  test('command 包含 oracle (oracle 是 command 子串) → 不移除', () => {
+    const plan = basePlan();
+    // command 是 oracle 的超集 → conductor 额外加了步骤, 不应过滤
+    plan.nodes['verify']!.command = 'bun run typecheck && bun test && echo done';
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeDefined();
+  });
+});
+
+// ── 2. 图连通性: 被删节点下游 depends_on 被无害重接 ─────────────────────────
+
+describe('graph connectivity after filter', () => {
+  test('被删节点的下游重接到上游, 无悬空引用', () => {
+    const plan = basePlan();
+    // verify (oracle) depends_on: [setup]; report depends_on: [verify]
+    // 移除 verify → report.depends_on 应重接到 [setup] (verify 的上游)
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['report']?.depends_on).toContain('setup');
+    expect(filtered.nodes['report']?.depends_on).not.toContain('verify');
+    assertGraphSound(filtered);
+  });
+
+  test('被删节点无上游时, 下游 depends_on 为空 (变根)', () => {
+    const plan: ConductorPlan = {
+      name: 'no-upstream',
+      nodes: {
+        verify: { executor: 'command', command: ORACLE_CMD },
+        report: { executor: 'leaf', goal: 'report', depends_on: ['verify'] },
+      },
+    };
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+    expect(filtered.nodes['report']?.depends_on ?? []).toHaveLength(0);
+    assertGraphSound(filtered);
+  });
+
+  test('被删节点有多个上游 + 多个下游', () => {
+    const plan: ConductorPlan = {
+      name: 'multi-fan',
+      nodes: {
+        a: { executor: 'leaf', goal: 'a' },
+        b: { executor: 'leaf', goal: 'b' },
+        verify: { executor: 'command', command: ORACLE_CMD, depends_on: ['a', 'b'] },
+        c: { executor: 'leaf', goal: 'c', depends_on: ['verify'] },
+        d: { executor: 'leaf', goal: 'd', depends_on: ['verify'] },
+      },
+    };
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['verify']).toBeUndefined();
+    // c, d 应分别获得 [a, b] (verify 的上游)
+    for (const down of ['c', 'd'] as const) {
+      const deps = filtered.nodes[down]?.depends_on ?? [];
+      expect(deps).toContain('a');
+      expect(deps).toContain('b');
+      expect(deps).not.toContain('verify');
+    }
+    assertGraphSound(filtered);
+  });
+
+  test('多级依赖链: A → oracle → B → C, 过滤后 B→A, C→B', () => {
+    const plan: ConductorPlan = {
+      name: 'chain',
+      nodes: {
+        A: { executor: 'leaf', goal: 'start' },
+        oracle: { executor: 'command', command: ORACLE_CMD, depends_on: ['A'] },
+        B: { executor: 'leaf', goal: 'mid', depends_on: ['oracle'] },
+        C: { executor: 'leaf', goal: 'end', depends_on: ['B'] },
+      },
+    };
+    const filtered = filterOracleCommandNodes(plan, ORACLE_CMD);
+    expect(filtered.nodes['oracle']).toBeUndefined();
+    expect(filtered.nodes['B']?.depends_on).toContain('A');
+    expect(filtered.nodes['C']?.depends_on).toContain('B');
+    assertGraphSound(filtered);
+  });
+});
+
+// ── 3. 回归: command-leaf 元字符闸未放宽 ──────────────────────────────────────
+
+describe('command-leaf metachar gate regression', () => {
+  test('含 && 的非 oracle 来源 command 仍被元字符闸拒绝', async () => {
+    const runner = createCommandLeafRunner({
+      allowlist: ['bun'],
+      spawn: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+    });
+    // 含 && 元字符 (非 oracle 来源, 这是 conductor 模型自己产出的 command)
+    const result = await runner({ command: 'bun test && echo done' });
+    expect(result.exitCode).toBe(-1);
+    expect(result.text).toContain('blocked');
+  });
+
+  test('含 | 的 command 仍被元字符闸拒绝', async () => {
+    const runner = createCommandLeafRunner({
+      allowlist: ['bun'],
+      spawn: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+    });
+    const result = await runner({ command: 'bun test | head -5' });
+    expect(result.exitCode).toBe(-1);
+    expect(result.text).toContain('blocked');
+  });
+
+  test('含 ; 的 command 仍被元字符闸拒绝', async () => {
+    const runner = createCommandLeafRunner({
+      allowlist: ['bun'],
+      spawn: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+    });
+    const result = await runner({ command: 'bun test; rm -rf /tmp/x' });
+    expect(result.exitCode).toBe(-1);
+    expect(result.text).toContain('blocked');
+  });
+
+  test('安全 command 通过 (无元字符)', async () => {
+    const runner = createCommandLeafRunner({
+      allowlist: ['bun'],
+      spawn: async () => ({ stdout: 'ok', stderr: '', exitCode: 0 }),
+    });
+    const result = await runner({ command: 'bun test' });
+    expect(result.exitCode).toBe(0);
+    expect(result.text).toBe('ok');
+  });
+});

--- a/src/harness/oracle-plan-filter.ts
+++ b/src/harness/oracle-plan-filter.ts
@@ -1,0 +1,73 @@
+/**
+ * src/harness/oracle-plan-filter —— plan 内 command 节点与 oracle-cmd 等价或被其包含时过滤。
+ *
+ * conductor 规划的 plan 常含一个 "verify" command 节点 (如 "bun run typecheck && bun test"),
+ * 与 oracle 已跑过的命令完全等价或为其子集 → 重跑 = 浪费 token + 时间。本模块在 plan 落地后、执行前移除这些节点。
+ *
+ * 过滤判定: 空白规范化后, command 与 oracle 相等 OR oracle 包含 command (command 是 oracle 子串)。
+ * 注意: command 包含 oracle (command 是超集) 时不过滤 — conductor 额外加了步骤, 保留。
+ *
+ * 连通性策略 (最小无害边重连): 被删节点的下游 depends_on 重接到被删节点的父依赖;
+ * 若被删节点无父依赖, 下游直接去掉该依赖 (变根)。选型理由: 保留下游节点的数据依赖拓扑,
+ * 仅跳过中间的 oracle 等价/子集节点, 不引入新边也不改变语义顺序。
+ */
+import type { ConductorPlan } from './conductor-plan';
+
+/** 规范化空白: 去首尾, 连续空白压成单空格。 */
+function normalizeWhitespace(s: string): string {
+  return s.trim().replace(/\s+/g, ' ');
+}
+
+/**
+ * 移除 plan 中 command 与 oracleCmd 等价或被其包含 (空白规范化后) 的节点。
+ * 下游 depends_on 重接到被删节点的父依赖 (最小无害边重连)。
+ */
+export function filterOracleCommandNodes(plan: ConductorPlan, oracleCmd: string): ConductorPlan {
+  const normalizedOracle = normalizeWhitespace(oracleCmd);
+  const ids = Object.keys(plan.nodes);
+  const removeIds = new Set<string>();
+
+  for (const id of ids) {
+    const node = plan.nodes[id]!;
+    if (node.executor === 'command' && node.command) {
+      const normalizedCmd = normalizeWhitespace(node.command);
+      if (normalizedCmd === normalizedOracle || normalizedOracle.includes(normalizedCmd)) {
+        removeIds.add(id);
+      }
+    }
+  }
+
+  if (removeIds.size === 0) return plan;
+
+  // 收集被删节点的上游 (用于重连下游)
+  const parentsOf = (id: string): string[] =>
+    (plan.nodes[id]?.depends_on ?? []).filter((d) => !removeIds.has(d));
+
+  // 重连: 下游的 depends_on 中, 被删 id 替换为其父依赖
+  const newNodes: typeof plan.nodes = {};
+  for (const id of ids) {
+    if (removeIds.has(id)) continue;
+    const node = plan.nodes[id]!;
+    const deps = node.depends_on ?? [];
+    const hasRemovedDep = deps.some((d) => removeIds.has(d));
+    if (!hasRemovedDep) {
+      newNodes[id] = node;
+      continue;
+    }
+    // 展开: 被删 dep → 其父依赖, 保留非被删 dep, 去重
+    const expanded: string[] = [];
+    const seen = new Set<string>();
+    for (const dep of deps) {
+      if (removeIds.has(dep)) {
+        for (const p of parentsOf(dep)) {
+          if (!seen.has(p)) { seen.add(p); expanded.push(p); }
+        }
+      } else {
+        if (!seen.has(dep)) { seen.add(dep); expanded.push(dep); }
+      }
+    }
+    newNodes[id] = { ...node, depends_on: expanded.length > 0 ? expanded : undefined };
+  }
+
+  return { ...plan, nodes: newNodes };
+}


### PR DESCRIPTION
Closes #2。

## 修法（issue 方向②）

plan 落地后、执行前的**确定性过滤器** `filterOracleCommandNodes`：command 节点内容与
`oracleCmd` 空白规范化后相等、或为其子串（oracle 已覆盖）→ 移除节点并做最小无害边重连
（下游 `depends_on` 重接被删节点父依赖；无父则变根）。command 为 oracle 超集 → 保留
（conductor 额外步骤）。**command-leaf 元字符闸未放宽**——对真 LLM 生成命令仍 fail-closed，
有回归测试钉死。

接线双路全覆盖：conductor 规划路 + D-7 预构造 plan 路（pathfinder slice 同受益）。
`ExecutorDagConfig.oracleCmd` 可选，省略 = 不过滤（back-compat）。dag-build 中 oracleCmd
提升为单一定义，外层 oracle 闸与过滤器字节一致。

## 验证

- 19 个新测试：空白规范化变体（空格/换行/Tab/首尾）、子集/超集语义、重连拓扑
  （多父多子/依赖链/变根/无悬空引用/无环）、元字符闸回归。
- 全量 oracle：`bun run typecheck && bun test` → **454 pass / 0 fail**。

## Dogfood 生产记录（K3 + MiMo fleet 产出，Aalto 审查）

- 执行阵型：`kimi-coding:k3` conductor+verifier、`mimo:mimo-2.5-pro-ultraspeed` agent/leaf
  执行（K3 agent-leaf 连续 3 跑 240s 停摆超时——单发调用正常、长会话工具循环挂死，疑晚高峰
  过载；换 MiMo leaves 后一跑即绿 + 2 轮自愈）。
- 审查修正两处：① fleet 漏接消费端（`dag-build.ts` 未传 `oracleCmd`，过滤器在复现路径上是
  死代码）——审查补接线；② `executor-dag-types.ts` JSDoc 插错位挤孤 verifier 文档——归位。
- 契约偏差记录：fleet 越 allowlist 修改了 `executor-dag*.ts`（派活契约禁改），未按纪律标
  `?` 上报。审查裁定：接缝选择本身正确（engine config 挂点使 iterate/execute/pathfinder
  slice 全部受益，优于 dag-build 局部过滤），**结果追认、程序违规记档**。
- 顺产观测性发现（建议另开 issue）：节点失败无败因留痕（caveman 压缩 + dag-runs.db 未启用）；
  agent-leaf 零输出停摆 240s 才判死，缺早期心跳闸；deepseek 兜底默认在无凭证环境连伤
  judge L2 / 内嵌 review / dream pump 三处。