### PR TITLE
fix(mcp): mcp 入口补 provider bootstrap — 引擎 leaf 静默秒败修复

### DIFF
--- a/src/harness/tui.ts
+++ b/src/harness/tui.ts
@@ -81,6 +81,10 @@ const userPickedModel = userArgs.includes('--model') || userArgs.includes('--pro
 // 工具面 = assembleOmdMcpTools 全装配 (v1 七工具: dag 四件套 + dag_research + memory 两件套, 接缝=真引擎/真记忆/真 research)。
 if (userArgs[0] === 'mcp') {
   logger.level = 'silent';
+  // mcp 入口不走 TUI boot → provider 注册需自带引导 (同 dag-* 短命进程), 否则引擎 leaf 因
+  // 注册表空而全部静默秒败 (settle(null) 空 output, 客户端只见"节点未完成")。stderr 打点协议安全。
+  const { bootstrapModelRuntime } = await import('../model/bootstrap');
+  bootstrapModelRuntime();
   const { runOmdMcpServer } = await import('../mcp/server');
   const { assembleOmdMcpTools } = await import('../mcp/assemble');
   await runOmdMcpServer(assembleOmdMcpTools());


### PR DESCRIPTION
## 病灶

`tui.ts` 的 `mcp` 分流入口（stdio MCP server）不经 TUI boot，`registerProvidersFromEnv()`
从未执行 → **server 进程内 provider 注册表恒空** → 任何需要 LLM 的工具
（`path_deliver` / `dag_run` / `dag_research`）的引擎 leaf 全部**静默秒败**：
`runNode().catch(() => null)` 丢弃异常 → `settle(null)` 造出
`{status:'failed', output:'', usage:{in:0,out:0}}` → 客户端只见「N/N 节点未完成」，零诊断
（#4 的最恶劣形态：连败因都没产生就被吞）。

## 修法

mcp 入口自带引导（与 `dag-*` 短命进程同范式，`bootstrapModelRuntime()` 文档注释本来就点名
了这个统一职责）；bootstrap 的打点走 stderr，协议通道（stdout）安全。一行 import + 一行调用。

## 实测（2026-07-20 笔记本, 冒烟全环）

补丁前：`path_map/add/tickets/rule`（零 LLM）全部正常，`path_deliver` 恒败「1/1 节点未完成」。
补丁后：**pathfinder 全环走通** — 开图 → grill/task 双票（blockedBy 前沿闸）→ 裁决 →
区域散尽 → 零 LLM 编译 slice → 引擎执行（mimo leaf, 296/631 tokens）→ 票翻 `delivered`。

## 顺带发现（另行处理）

- **preset 模型名漂移**：`role-presets.ts` 的 `MIMO_ULTRASPEED = 'mimo:mimo-2.5-pro-ultraspeed'`
  在 api.xiaomimimo.com 端点返回 `400 Unsupported model` — 该端点实际模型名为
  **`mimo-v2.5-pro-ultraspeed`**（带 v，与旧 XIHE_RUNTIME_MODEL 一致）。另开 issue。
- 裸 `catch(() => null)` 丢异常对象是 #4 的病灶本体（settle 侧拿不到败因），本 PR 不动它，
  修法归 #4。